### PR TITLE
Create MANIFEST.in to include README.md in package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+README.md


### PR DESCRIPTION
fixes FileNotFoundError as of pip version 20.1.1. Otherwise everything still seems to be working.

```
 > pip install celery_mutex
Defaulting to user installation because normal site-packages is not writeable
Collecting celery_mutex
  Using cached celery_mutex-0.1.0.tar.gz (3.5 kB)
    ERROR: Command errored out with exit status 1:
     command: /usr/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-3i7agsfj/celery-mutex/setup.py'"'"'; __file__='"'"'/tmp/pip-install-3i7agsfj/celery-mutex/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-ecqgth6e
         cwd: /tmp/pip-install-3i7agsfj/celery-mutex/
    Complete output (9 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-3i7agsfj/celery-mutex/setup.py", line 33, in <module>
        long_description=read('README.md'),
      File "/tmp/pip-install-3i7agsfj/celery-mutex/setup.py", line 12, in read
        return codecs.open(os.path.join(here, *parts), 'r').read()
      File "/usr/lib/python3.6/codecs.py", line 897, in open
        file = builtins.open(filename, mode, buffering)
    FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pip-install-3i7agsfj/celery-mutex/README.md'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```